### PR TITLE
Optionals with some?.that : 12 were treated for ternary space alignme…

### DIFF
--- a/XcodeFormatter/Core/Regex/MatchPattern.swift
+++ b/XcodeFormatter/Core/Regex/MatchPattern.swift
@@ -29,7 +29,7 @@ enum MatchPattern: String {
     /// Example:  true ?  1   :    0
     /// CP1 = ` ` CP2 = `  ` CP3 = `   ` CP4 = `    `
     ///
-    case ternaryOperator = "[^\\t]([\\s]*)(?:\\?)([\\s]*)(?:[^\\s:]+)([\\s]*)(?::)([\\s]*)[\\S]"
+    case ternaryOperator = "[^\\t]([\\s]*)(?:\\?)([\\s]*)(?:[^\\s:.\\[]+)([\\s]*)(?::)([\\s]*)[\\S]"
     
     
     //Other patterns

--- a/XcodeFormatterTests/TernaryOperatorSpacerTests.swift
+++ b/XcodeFormatterTests/TernaryOperatorSpacerTests.swift
@@ -53,6 +53,18 @@ class TernaryOperatorSpacerTests: XCTestCase {
         assertThat(input, produces: expected)
     }
     
+    func testThat_OptionalChaing_IsNotTreatedForTernaryOperation() {
+        let input = "let  b = thisOne?.map({$0.that()})flatmap{$0} : asd \n"
+        let expected = input
+        assertThat(input, produces: expected)
+    }
+    
+    func testThat_OptionalDictionaryLookup_AreNotTreatedForTernaryOperation() {
+        let input = "let b = dictionaryOptional?[\"some\"] : that \n"
+        let expected = input
+        assertThat(input, produces: expected)
+    }
+    
     private func assertThat(_ input: String, produces expected: String) {
         let output = LintSpace().correctTernaryOperator(line: input)
         XCTAssert(output == expected)


### PR DESCRIPTION
…nt. Which produces bad code. This fixes that
